### PR TITLE
Add "dotenv" as a runtime dependency to the gemspec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,6 @@ gemspec
 
 group :test do
   gem "shoulda-context", "~> 2.0"
-  gem "dotenv", "~> 3.0", ">= 3.0.2"
 end
 
 # gem "rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     ruby-lsp-shoulda-context (0.4.2)
+      dotenv (~> 3.0, >= 3.0.2)
       ruby-lsp (~> 0.16.6, >= 0.16.0)
 
 GEM
@@ -83,7 +84,6 @@ PLATFORMS
 DEPENDENCIES
   bump (~> 0.10.0)
   debug (~> 1.8)
-  dotenv (~> 3.0, >= 3.0.2)
   minitest (~> 5.20)
   minitest-reporters (~> 1.6)
   pry

--- a/ruby-lsp-shouda-context.gemspec
+++ b/ruby-lsp-shouda-context.gemspec
@@ -48,5 +48,6 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.add_runtime_dependency("dotenv", "~> 3.0", ">= 3.0.2")
   spec.add_runtime_dependency("ruby-lsp", "~> 0.16.6", ">= 0.16.0")
 end


### PR DESCRIPTION
Without having the dotenv gem installed the LSP will not start. By adding it as a dependency the dotenv gem will be installed automatically, if the user adds this addon to their bundle.