### PR TITLE
chore: update ruby-lsp to version 0.23.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gemspec
 
 group :test do
   gem "shoulda-context", "~> 2.0"
-  gem "ruby-lsp", "~> 0.22.0"
+  gem "ruby-lsp", "~> 0.23.0"
 end
 
 # gem "rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,7 +22,7 @@ GEM
       reline (>= 0.4.2)
     json (2.7.1)
     language_server-protocol (3.17.0.3)
-    logger (1.6.1)
+    logger (1.6.5)
     method_source (1.0.0)
     minitest (5.21.2)
     minitest-reporters (1.6.1)
@@ -34,7 +34,7 @@ GEM
     parser (3.3.0.5)
       ast (~> 2.4.1)
       racc
-    prism (1.2.0)
+    prism (1.3.0)
     pry (0.14.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -43,7 +43,7 @@ GEM
     racc (1.7.3)
     rainbow (3.1.1)
     rake (13.1.0)
-    rbs (3.6.1)
+    rbs (3.8.1)
       logger
     rdoc (6.6.2)
       psych (>= 4.0.0)
@@ -70,14 +70,14 @@ GEM
       rubocop (~> 1.51)
     rubocop-sorbet (0.7.5)
       rubocop (>= 0.90.0)
-    ruby-lsp (0.22.1)
+    ruby-lsp (0.23.5)
       language_server-protocol (~> 3.17.0)
       prism (>= 1.2, < 2.0)
       rbs (>= 3, < 4)
       sorbet-runtime (>= 0.5.10782)
     ruby-progressbar (1.13.0)
     shoulda-context (2.0.0)
-    sorbet-runtime (0.5.11670)
+    sorbet-runtime (0.5.11751)
     stringio (3.1.0)
     unicode-display_width (2.5.0)
 
@@ -95,7 +95,7 @@ DEPENDENCIES
   rubocop-rake (~> 0.6.0)
   rubocop-shopify (~> 2.14)
   rubocop-sorbet (~> 0.7)
-  ruby-lsp (~> 0.22.0)
+  ruby-lsp (~> 0.23.0)
   ruby-lsp-shoulda-context!
   shoulda-context (~> 2.0)
 

--- a/lib/ruby_lsp/ruby-lsp-shoulda-context/addon.rb
+++ b/lib/ruby_lsp/ruby-lsp-shoulda-context/addon.rb
@@ -8,7 +8,7 @@ require "dotenv/load"
 require_relative "code_lens"
 require_relative "../shoulda_context/version"
 
-RubyLsp::Addon.depend_on_ruby_lsp!("~> 0.22.0")
+RubyLsp::Addon.depend_on_ruby_lsp!("~> 0.23.0")
 
 module RubyLsp
   module ShouldaContext

--- a/test/ruby-lsp/shoulda_context_test.rb
+++ b/test/ruby-lsp/shoulda_context_test.rb
@@ -32,6 +32,8 @@ module RubyLsp
             },
           )
 
+          server.pop_response # Drop the notification change message
+
           response = server.pop_response
           response = response.response
 
@@ -91,6 +93,8 @@ module RubyLsp
               },
             },
           )
+
+          server.pop_response # Drop the notification change message
 
           response = server.pop_response
           response = response.response
@@ -172,6 +176,8 @@ module RubyLsp
               },
             },
           )
+
+          server.pop_response # Drop the notification change message
 
           response = server.pop_response
           response = response.response


### PR DESCRIPTION
Updated the ruby-lsp version to 0.23.0 to avoid skipping addon on updated environments.